### PR TITLE
SONARMSBRU-260 Analysis of some 'test' projects might fail during the…

### DIFF
--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -450,7 +450,7 @@
 
     <PropertyGroup Condition=" $(SonarQubeDisableRoslynCodeAnalysis) == 'true' ">
       <ErrorLog></ErrorLog>
-      <ResolvedCodeAnalysisRuleSet></ResolvedCodeAnalysisRuleSet>
+      <!-- The ResolvedCodeAnalysisRuleSet property is not changed, which means the ruleset and the analyzers are not modified for test projects. -->
     </PropertyGroup>
     <!-- else -->
     <CallTarget Targets="SetRoslynCodeAnalysisProperties"
@@ -492,7 +492,7 @@
       BeforeTargets="WriteSonarQubeProjectData">
 
     <ItemGroup>
-      
+
       <SonarQubeSetting Include="sonar.$(SQLanguage).roslyn.reportFilePath"
          Condition=" $(ErrorLog) != '' AND  $([System.IO.File]::Exists($(ErrorLog))) == 'true' ">
         <Value>$(ErrorLog)</Value>

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
@@ -50,15 +50,15 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
 
         public static void AssertExpectedPropertyValue(ProjectInstance projectInstance, string propertyName, string expectedValue)
         {
-            ProjectPropertyInstance propertyInstance = AssertPropertyExists(projectInstance, propertyName);
-            Assert.AreEqual(expectedValue, propertyInstance.EvaluatedValue, "Property '{0}' does not have the expected value", propertyName);
-        }
-
-        public static ProjectPropertyInstance AssertPropertyExists(ProjectInstance projectInstance, string propertyName)
-        {
             ProjectPropertyInstance propertyInstance = projectInstance.GetProperty(propertyName);
+            if (expectedValue == null &&
+                propertyInstance == null)
+            {
+                return;
+            }
+
             Assert.IsNotNull(propertyInstance, "The expected property does not exist: {0}", propertyName);
-            return propertyInstance;
+            Assert.AreEqual(expectedValue, propertyInstance.EvaluatedValue, "Property '{0}' does not have the expected value", propertyName);
         }
 
         public static void AssertPropertyDoesNotExist(ProjectInstance projectInstance, string propertyName)

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -198,7 +198,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             logger.AssertTargetNotExecuted(TargetConstants.SetRoslynAnalysisPropertiesTarget);
             BuildAssertions.AssertTargetSucceeded(result, TargetConstants.OverrideRoslynAnalysisTarget);
 
-            AssertCodeAnalysisIsDisabled(result);
+            AssertCodeAnalysisIsDisabled(result, null);
         }
 
         [TestMethod]
@@ -209,6 +209,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             BuildLogger logger = new BuildLogger();
             WellKnownProjectProperties properties = new WellKnownProjectProperties();
             properties.SonarQubeExclude = "TRUE"; // mark the project as excluded
+            properties.ResolvedCodeAnalysisRuleset = "Dummy value";
 
             ProjectRootElement projectRoot = CreateValidProjectSetup(properties);
 
@@ -220,7 +221,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             logger.AssertTargetNotExecuted(TargetConstants.SetRoslynAnalysisPropertiesTarget);
             BuildAssertions.AssertTargetSucceeded(result, TargetConstants.OverrideRoslynAnalysisTarget);
 
-            AssertCodeAnalysisIsDisabled(result);
+            AssertCodeAnalysisIsDisabled(result, properties.ResolvedCodeAnalysisRuleset);
         }
 
         #endregion
@@ -365,11 +366,11 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
         #region Checks
 
-        private static void AssertCodeAnalysisIsDisabled(BuildResult result)
+        private static void AssertCodeAnalysisIsDisabled(BuildResult result, string expectedResolvedCodeAnalysisRuleset)
         {
             // Check the ruleset and error log are not set
             AssertExpectedErrorLog(result, string.Empty);
-            AssertExpectedResolvedRuleset(result, string.Empty);
+            AssertExpectedResolvedRuleset(result, expectedResolvedCodeAnalysisRuleset);
         }
 
         /// <summary>


### PR DESCRIPTION
… compilation as the Roslyn 'ruleset' parameter is removed by the Scanner for MSBuild