### PR TITLE
SONARCS-634: Command line argument /d:sonar.sourceEncoding=xxx is now…

### DIFF
--- a/SonarScanner.Shim/PropertiesFileGenerator.cs
+++ b/SonarScanner.Shim/PropertiesFileGenerator.cs
@@ -268,8 +268,19 @@ namespace SonarScanner.Shim
             AnalysisProperties properties = new AnalysisProperties();
 
             properties.AddRange(config.GetAnalysisSettings(false).GetAllProperties()
-                // Strip out any sensitive properties
-                .Where(p => !p.ContainsSensitiveData()));
+                      // Strip out any sensitive properties
+                      .Where(p => !p.ContainsSensitiveData()));
+
+            // Add default value for sonar.sourceEncoding if it is not already set
+            Property encodingProperty;
+            if (!Property.TryGetProperty(SonarProperties.SourceEncoding, properties, out encodingProperty))
+            {
+                properties.Add(new Property
+                {
+                    Id = SonarProperties.SourceEncoding,
+                    Value = "UTF-8"
+                });
+            }
 
             // There are some properties we want to override regardless of what the user sets
             AddOrSetProperty(VSBootstrapperPropertyKey, "false", properties, logger);

--- a/SonarScanner.Shim/PropertiesWriter.cs
+++ b/SonarScanner.Shim/PropertiesWriter.cs
@@ -233,10 +233,6 @@ namespace SonarScanner.Shim
             AppendKeyValue(sb, SonarProperties.ProjectBaseDir, ComputeProjectBaseDir());
 
             sb.AppendLine();
-
-            sb.AppendLine("# FIXME: Encoding is hardcoded");
-            AppendKeyValue(sb, SonarProperties.SourceEncoding, "UTF-8");
-            sb.AppendLine();
         }
 
         /// <summary>

--- a/Tests/SonarScanner.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -141,6 +141,48 @@ namespace SonarScanner.Shim.Tests
         }
 
         [TestMethod]
+        public void FileGen_ValidFiles_SourceEncoding_DefaultValue()
+        {
+            // Arrange
+            string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+
+            CreateProjectWithFiles("withFiles1", testDir);
+
+            TestLogger logger = new TestLogger();
+            AnalysisConfig config = CreateValidConfig(testDir);
+
+            // Act
+            ProjectInfoAnalysisResult result = PropertiesFileGenerator.GenerateFile(config, logger);
+
+            // Assert
+            var settingsFileContent = File.ReadAllText(result.FullPropertiesFilePath);
+            StringAssert.Contains(settingsFileContent, "sonar.sourceEncoding=UTF-8");
+        }
+
+        [TestMethod]
+        public void FileGen_ValidFiles_SourceEncoding_Provided()
+        {
+            // Arrange
+            string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+
+            CreateProjectWithFiles("withFiles1", testDir);
+
+            TestLogger logger = new TestLogger();
+            AnalysisConfig config = CreateValidConfig(testDir);
+
+            config.LocalSettings = new AnalysisProperties();
+            config.LocalSettings.Add(new Property { Id = SonarProperties.SourceEncoding, Value = "test-encoding-here" });
+
+            // Act
+            ProjectInfoAnalysisResult result = PropertiesFileGenerator.GenerateFile(config, logger);
+
+            // Assert
+            var settingsFileContent = File.ReadAllText(result.FullPropertiesFilePath);
+            StringAssert.Contains(settingsFileContent, "sonar.sourceEncoding=test-encoding-here");
+        }
+
+
+        [TestMethod]
         public void FileGen_ValidFiles_WithAlreadyValidSarif()
         {
             // Arrange

--- a/Tests/SonarScanner.Shim.Tests/PropertiesWriterTest.cs
+++ b/Tests/SonarScanner.Shim.Tests/PropertiesWriterTest.cs
@@ -114,9 +114,6 @@ sonar.projectVersion=1.0
 sonar.working.directory=C:\\my_folder\\.sonar
 sonar.projectBaseDir={5}
 
-# FIXME: Encoding is hardcoded
-sonar.sourceEncoding=UTF-8
-
 sonar.modules=DB2E5521-3172-47B9-BA50-864F12E6DFFF,B51622CF-82F4-48C9-9F38-FB981FAFAF3A,DA0FCD82-9C5C-4666-9370-C7388281D49B
 
 ",
@@ -175,9 +172,6 @@ sonar.projectName=my_project_name
 sonar.projectVersion=1.0
 sonar.working.directory=C:\\my_folder\\.sonar
 sonar.projectBaseDir={1}
-
-# FIXME: Encoding is hardcoded
-sonar.sourceEncoding=UTF-8
 
 sonar.modules=9507E2E6-7342-4A04-9CB9-B0C47C937019
 


### PR DESCRIPTION
… correctly passed to the SonarQube server; the default value is UTF-8 if no parameter was provided;