### PR TITLE
Handle WebException on incorrect authentication.

### DIFF
--- a/SonarQube.Common/Resources.Designer.cs
+++ b/SonarQube.Common/Resources.Designer.cs
@@ -242,6 +242,15 @@ namespace SonarQube.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not authorize while connecting to the SonarQube server. Check your credentials and try again..
+        /// </summary>
+        public static string ERROR_UnauthorizedConnection {
+            get {
+                return ResourceManager.GetString("ERROR_UnauthorizedConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The name of the SonarQube server could not be resolved. Check the url is correct and that the server is available. Url: {0}.
         /// </summary>
         public static string ERROR_UrlNameResolutionFailed {

--- a/SonarQube.Common/Resources.resx
+++ b/SonarQube.Common/Resources.resx
@@ -248,4 +248,7 @@
   <data name="WARN_ExecutionTimedOutNotKilled" xml:space="preserve">
     <value>Timed out after waiting {0} ms for process {1} to complete: it could not be terminated and might still be running.</value>
   </data>
+  <data name="ERROR_UnauthorizedConnection" xml:space="preserve">
+    <value>Could not authorize while connecting to the SonarQube server. Check your credentials and try again.</value>
+  </data>
 </root>

--- a/SonarQube.Common/Utilities.cs
+++ b/SonarQube.Common/Utilities.cs
@@ -165,6 +165,12 @@ namespace SonarQube.Common
                 return true;
             }
 
+            if (response != null && response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                logger.LogError(Resources.ERROR_UnauthorizedConnection, response.ResponseUri);
+                return true;
+            }
+
             if (ex.Status == WebExceptionStatus.NameResolutionFailure)
             {
                 logger.LogError(Resources.ERROR_UrlNameResolutionFailed, hostUrl);


### PR DESCRIPTION
Previously the scanner threw an unhandled exception when connecting to the server with incorrect credentials and crashed the application. This fix handles the exception with http unauthorized response and adds it to the logging instead.